### PR TITLE
44 support for optional keys in yaml files

### DIFF
--- a/datadict/datadict_yaml.py
+++ b/datadict/datadict_yaml.py
@@ -85,15 +85,16 @@ def combine_column_lists(current_yml, expected_yml) -> dict:
 			    f"Added data_type '{column['data_type']}' to '{column['name']}' in model '{current_yml['name']}'"
 		    )
 
-    sort_order = ['name', 'data_type', 'description', 'tests']
+    sort_order = ['name', 'data_type', 'description', 'tests', 'data_tests', 'unit_tests', 'meta']
     
     for column in combined_yaml['columns']:
-        column['description'] = column.get('description', '')  
-        
-        if 'tests' in column:
-            column['tests'] = column['tests']
-        else:
-            column.pop('tests', None)
+        column['description'] = column.get('description', '')
+
+        for optional_columns in ['tests', 'data_tests', 'unit_tests', 'meta']:
+            if optional_columns in column:
+                column[optional_columns] = column[optional_columns]
+            else:
+                column.pop(optional_columns, None)
 
         column_sorted = {key: column[key] for key in sort_order if key in column}
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-datadict"
-version = "0.2.1"
+version = "0.3.0"
 description = "Python CLI for automating the application of consistent field definitions to large multi-layered dbt projects."
 authors = ["tom <tom@tasman.ai>"]
 readme = "README.md"


### PR DESCRIPTION
The properties `data_tests`, `unit_tests` and `meta` will not be removed when running datadict anymore with this PR.

It can be tested with test PyPi `python -m pip install --extra-index-url https://test.pypi.org/simple/ dbt-datadict==0.3.0` 