### PR TITLE
Update the CI workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,71 +1,23 @@
-# Triggered on push events to the main branch.
-# Publishes the package to PyPI only on tag pushes.
-
-name: 🐍 📦 Publish Python distribution to PyPI and TestPyPI
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
+name: 🐍 📦 Publish Python distribution to PyPI
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    tags:
-      - v*
+  release:
+    types: ["published"]
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
-  build:
-    name: Build distribution 📦
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v6
-    - name: Build distribution 📦
-      run: uv build
-    - name: Store the distribution artifact 🥶
-      uses: actions/upload-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-
   publish-to-pypi:
-    name: Publish distro to PyPI 🐍 📦
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     runs-on: ubuntu-latest
-    needs: ["build"]
     environment:
       name: prod
       url: https://pypi.org/p/dbt-datadict
-    permissions:
-      id-token: write
     steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v6
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution 📦 to PyPI
-      run: uv publish --token ${{ secrets.PYPI_TOKEN }}
-
-  publish-to-testpypi:
-    name: Publish distro to TestPyPI 🐍 📦
-    runs-on: ubuntu-latest
-    needs: ["build"]
-    environment:
-      name: test
-      url: https://test.pypi.org/p/dbt-datadict
-    permissions:
-      id-token: write
-    steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v6
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution 📦 to TestPyPI
-      run: uv publish --index testpypi --token ${{ secrets.PYPI_TOKEN }}
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv build
+      - run: uv publish --token ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
+name: 🧪 Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️ Check out repository
+        uses: actions/checkout@v4
+
+      - name: 📦 Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ">=0.6.0,<1.0.0"
+          enable-cache: true
+
+      - name: 🔨 Install dependencies
+        run: uv sync --no-default-groups
+
+      - name: ✅ Run unit tests
+        run: uv run python -m test.test

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ publish-test: build ##& Publish the datadict Python package to Test PyPI
 	uv publish --index testpypi
 
 build: uv ## Build the datadict Python package
-	uv build
+	rm -rf dist/ && uv build
 
 clean: ## Uninstall the dbt virtual environment
 	@echo Uninstalling the uv virtual environment.

--- a/test/test.py
+++ b/test/test.py
@@ -532,14 +532,14 @@ class TestYaml(unittest.TestCase):
         current_yml = {
             "name": "Model1",
             "columns": [
-                {"name": "Column1", "type": "int"},
-                {"name": "Column2", "type": "str"},
+                {"name": "Column1", "data_type": "int"},
+                {"name": "Column2", "data_type": "str"},
             ],
         }
         expected_yml = {
             "columns": [
-                {"name": "Column1", "type": "int"},
-                {"name": "Column2", "type": "str"},
+                {"name": "Column1", "data_type": "int"},
+                {"name": "Column2", "data_type": "str"},
             ]
         }
         result = datadict_yaml.combine_column_lists(current_yml, expected_yml)
@@ -551,31 +551,31 @@ class TestYaml(unittest.TestCase):
         current_yml = {
             "name": "Model1",
             "columns": [
-                {"name": "Column1", "type": "int"},
+                {"name": "Column1", "data_type": "int"},
             ],
         }
         expected_yml = {
             "columns": [
-                {"name": "Column1", "type": "int"},
-                {"name": "Column2", "type": "str"},
+                {"name": "Column1", "data_type": "int", "description": ""},
+                {"name": "Column2", "data_type": "str", "description": ""},
             ]
         }
         result = datadict_yaml.combine_column_lists(current_yml, expected_yml)
         self.assertEqual(result["updated"], True)
-        self.assertIn({"name": "Column2", "type": "str"}, result["yaml"]["columns"])
+        self.assertIn({"name": "Column2", "data_type": "str", "description": ""}, result["yaml"]["columns"])
 
     def test_combine_column_lists_additional_columns(self):
         # Test when there are additional columns
         current_yml = {
             "name": "Model1",
             "columns": [
-                {"name": "Column1", "type": "int"},
-                {"name": "Column2", "type": "str"},
+                {"name": "Column1", "data_type": "int"},
+                {"name": "Column2", "data_type": "str"},
             ],
         }
         expected_yml = {
             "name": "Model1",
-            "columns": [{"name": "Column1", "type": "int"}],
+            "columns": [{"name": "Column1", "data_type": "int", "description": ""}],
         }
         result = datadict_yaml.combine_column_lists(current_yml, expected_yml)
         self.assertEqual(result["updated"], True)
@@ -586,12 +586,12 @@ class TestYaml(unittest.TestCase):
         current_yml = {"name": "Model1"}
         expected_yml = {
             "columns": [
-                {"name": "Column1", "type": "int"},
+                {"name": "Column1", "data_type": "int", "description": ""},
             ]
         }
         result = datadict_yaml.combine_column_lists(current_yml, expected_yml)
         self.assertEqual(result["updated"], True)
-        self.assertIn({"name": "Column1", "type": "int"}, result["yaml"]["columns"])
+        self.assertIn({"name": "Column1", "data_type": "int", "description": ""}, result["yaml"]["columns"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two CI workflow changes:

- Added a new workflow to run unit tests on PRs
- Updated the publish workflow to no longer publish to Test PyPI

Additionally, fix failing unit tests and improve the `make build` command.

## Details

The main change that needs to be explained is the change to the publish workflow.

For security, PyPI does not allow for a filename to be reused, even once a project has been deleted and recreated:

- https://test.pypi.org/help/#file-name-reuse

This means that if we were to, say, publish the package to TestPyPI locally (using the `make publish-test`), then the CI would fail to publish the package to TestPyPI as the published package would already exist.

This is also why the publish workflow fails on releases (and, in fact, any push to main where the version hasn't changed): the test PyPI package is deployed on the push to main, so attempting to publish to test PyPI again on release will fail.

The recommended developer workflow for releasing is to instead publish to test PyPI manually (using the `make publish-test` command) for manual testing locally, and then to only publish to prod PyPI in CI. This is consistent with the sets described in the repo's developer guide:

- https://github.com/TasmanAnalytics/dbt-datadict/blob/main/docs/developer_guide.md