### PR TITLE
Update codeowners to DE team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,1 @@
-# This CODEOWNERS file defines ownership of specific folders within this repo
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# these teams/reviewers will be requested for
-# review when someone opens a pull request.
-*       @TasmanAnalytics/engineering-leads @sakce
-
-
-# All files in the below directory and any of its
-# subdirectories will be owned by the specified team
+* @TasmanAnalytics/data-engineering


### PR DESCRIPTION
## Summary

With @sakce leaving (😭😭😭) we need to update the [CODEOWNERS](https://github.com/TasmanAnalytics/dbt-datadict/blob/main/.github/CODEOWNERS), as he's currently the only code owner.

This replaces `@sakce` with `@TasmanAnalytics/data-engineering`, so note that this change also requires this team being added explicitly as a contributor to this repo.