### PR TITLE
Nix Flakes for system level dependency management.

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -4,37 +4,91 @@
 
 This is a Python project which uses [uv](https://github.com/astral-sh/uv) for package management.
 
-The [Makefile](https://github.com/TasmanAnalytics/dbt-datadict/blob/main/Makefile) has several commands to help with development tasks, such as:
+### Prerequisites: Installing Nix (Recommended)
+
+This project includes a Nix flake that provides a reproducible development environment with all required tools. We recommend using the [Determinate Systems Nix installer](https://determinate.systems/posts/determinate-nix-installer):
 
 ```shell
-make uv     # Install uv, sync dependencies, install pre-commit hooks
+# macOS, Linux, or WSL (Windows Subsystem for Linux)
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+```
+
+> [!NOTE]
+>
+> **Windows users:** We recommend using WSL (Windows Subsystem for Linux) to run Nix. Follow the [WSL installation guide](https://learn.microsoft.com/en-us/windows/wsl/install) first, then install Nix inside your WSL environment.
+
+After installation, you may need to restart your terminal or reboot your system for the `nix` command to become available.
+
+### Quick Start: Using the Nix Flake (Recommended)
+
+Once Nix is installed, enter the development environment with:
+
+```shell
+nix develop -c $SHELL
+```
+
+This will:
+- Automatically install all required dependencies (Python, uv, git, etc.)
+- Set up the Python virtual environment using uv
+- Install pre-commit hooks
+- Launch your preferred shell (zsh, bash, fish, etc.)
+
+The [Makefile](https://github.com/TasmanAnalytics/dbt-datadict/blob/main/Makefile) has several commands to help with development tasks:
+
+```shell
 make build  # Build the package locally
 make test   # Run the tests
 make lint   # Run the linters
 make docs   # Build and serve the documentation locally
 ```
 
+> [!TIP]
+>
+> Create a shell alias for convenience:
+> ```shell
+> alias nixdev='nix develop -c $SHELL'
+> ```
+
+### Alternative Setup: Manual Installation
+
+If you prefer not to use Nix, you can set up the environment manually.
+
+The [Makefile](https://github.com/TasmanAnalytics/dbt-datadict/blob/main/Makefile) includes a command to install uv and sync dependencies:
+
+```shell
+make uv     # Install uv, sync dependencies, install pre-commit hooks
+```
+
 If you're using a system without `make`, you can run the equivalent commands directly:
 
 ```shell
-# Install uv and sync dependencies (Windows)
-powershell -c "irm https://astral.sh/uv/install.ps1 | more"
+# Install uv and sync dependencies (macOS/Linux)
+curl -LsSf https://astral.sh/uv/install.sh | sh
 uv sync --all-groups
-pre-commit install
+uv run pre-commit install --install-hooks
+
+# Install uv and sync dependencies (Windows)
+# First, review the installation script:
+powershell -c "irm https://astral.sh/uv/install.ps1 | more"
+# Then, if you're happy with it, install:
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+uv sync --all-groups
+uv run pre-commit install --install-hooks
 
 # Build the package locally
 uv build
 
 # Run the tests
-pytest -v
+uv run pytest -v
 
 # Run the linters
-pre-commit run --all-files --hook-stage pre-commit
-pre-commit run --all-files --hook-stage pre-push
+uv run pre-commit run --all-files --hook-stage pre-commit
+uv run pre-commit run --all-files --hook-stage pre-push
 
 # Build and serve the documentation locally
-mkdocs build
-mkdocs serve
+uv run mkdocs build
+uv run mkdocs serve
 ```
 
 ## Publishing a new release

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770770419,
+        "narHash": "sha256-iKZMkr6Cm9JzWlRYW/VPoL0A9jVKtZYiU4zSrVeetIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c5e707c6b5339359a9a9e215c5e66d6d802fd7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,97 @@
+{
+  description = "Tasman dbt-datadict, Tool for managing consistent column descriptions across a dbt project.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      ...
+    }:
+    let
+      # Systems supported
+      allSystems = [
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-darwin" # MacOS M chips
+      ];
+
+      # Helper to provide system-specific attributes
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs {
+              inherit system;
+              # NOTE: Uncomment this if using non-foss programs (like terraform)
+              # config.allowUnfree = true;
+            };
+          }
+        );
+
+    in
+    {
+      devShells = forAllSystems (
+        { pkgs }:
+        {
+
+          default = pkgs.mkShell {
+            # There is no variable set by default for a Nix shell, this gives us
+            #   something to use to detect if we're in.
+            NIX_DEVELOP_SHELL = "true";
+
+            # Tell uv to use the Nix-provided Python, not download its own
+            UV_PYTHON_DOWNLOADS = "never";
+
+            # The Nix packages provided in the environment
+            packages = (
+              with pkgs;
+              [
+                # Command runners
+                # For `make`
+                gnumake
+                just
+
+                # Used by command runners
+                curl
+                # for `sed`
+                gnused
+                # For `fgrep`
+                gnugrep
+
+                # Standard python stuff
+                python313
+                uv
+
+                # NOTE: Even though this should be installed by default, some darwin
+                #   shells don't seem to detect it.
+                #   This also means that re-running `nix develop` while in a shell
+                #   causes issues as the system git and shell git conflict, so exit
+                #   your dev shell, `exit`, before re-entering.
+                # TODO: Figure out why this happens on some Macs but not others, so
+                #   that this isn't needed anymore.
+                git
+
+                # For formatting nix files, with `nixfmt`
+                nixfmt-rfc-style
+              ]
+            );
+            shellHook = ''
+              # Sync uv, create venv, and set up pre-commit hooks.
+              make uv
+
+              # Activate the venv uv created
+              if [ -d .venv ]; then
+                source .venv/bin/activate
+              fi
+            '';
+
+          };
+        }
+      );
+    };
+
+}


### PR DESCRIPTION
This PR bring in Nix for managing project dependencies to improve the development setup and experience!

With Nix installed, running `nix develop` (or `nix develop -c $SHELL` to keep your shell) is all a developer needs to begin working on the project.

Nix also locks the system dependencies that developers use, everyone will now be using the same versions of `sed`, `make`, `curl`, `grep`, etc.. This should prevent issues with developers working on different systems that may not default to `gnu` versions of these tools, ensuring consistent behaviour with flags used.

The flake should now act as an exhaustive list of what is needed to work on this project. See the `docs/developer_guide.md` to see how to get set up (and update dependencies, when needed).

The stable channel, `nixos-25.11`, has been chosen over unstable, this means there will be a slight delay before getting the latest version of packages, this can be changed to `nixos-unstable` if we need the bleeding edge in the future (or mixing inputs).

A subsequent PR will be raised to bring in `direnv` compatibility for an even more seamless setup :)